### PR TITLE
Retry failed delivery on the next session properly

### DIFF
--- a/_examples/pubsub/pubsub.go
+++ b/_examples/pubsub/pubsub.go
@@ -107,6 +107,7 @@ func publish(sessions chan chan session, messages <-chan message) {
 
 		log.Printf("publishing...")
 
+PUBLISH:
 		for {
 			var body message
 			select {
@@ -126,7 +127,7 @@ func publish(sessions chan chan session, messages <-chan message) {
 				if err != nil {
 					pending <- body
 					pub.Close()
-					break
+					break PUBLISH
 				}
 
 			case body, running = <-reading:


### PR DESCRIPTION
A "break" statement just terminates execution of the innermost "select", should break from innermost "for"
